### PR TITLE
[postgresql-simple] Fix queries that return multiple rows

### DIFF
--- a/postgresql-simple/src/Database/YeshQL/PostgreSQL.hs
+++ b/postgresql-simple/src/Database/YeshQL/PostgreSQL.hs
@@ -153,14 +153,14 @@ mkQueryBody query = do
                             [| \qstr params conn -> fmap fromIntegral (PostgreSQL.execute conn (fromString qstr) params) |]
                         ReturnTuple Many tys ->
                             case tys of
-                             [t] -> [| \qstr params conn -> _ $ PostgreSQL.query conn (fromString qstr) params |]
+                             [t] -> [| \qstr params conn -> map fromOnly <$> PostgreSQL.query conn (fromString qstr) params |]
                              _ -> [| \qstr params conn -> PostgreSQL.query conn (fromString qstr) params |]
                         ReturnTuple One tys ->
                             case tys of
                               [t] -> [| \qstr params conn -> fmap (fmap fromOnly . headMay) (PostgreSQL.query conn (fromString qstr) params) |]
                               _ -> [| \qstr params conn -> fmap headMay (PostgreSQL.query conn (fromString qstr) params) |]
                         ReturnRecord Many _ ->
-                            [| \qstr params conn -> _ |]
+                            [| \qstr params conn -> PostgreSQL.query conn (fromString qstr) params |]
                         ReturnRecord One _ ->
                             [| \qstr params conn -> fmap headMay (PostgreSQL.query conn (fromString qstr) params) |]
         rawQueryFunc = [| \qstr conn -> () <$ execute_ conn (fromString qstr) |]

--- a/postgresql-simple/tests/Database/YeshQL/PostgreSQL/Tests.hs
+++ b/postgresql-simple/tests/Database/YeshQL/PostgreSQL/Tests.hs
@@ -50,6 +50,8 @@ tests conn =
     , testRecordReturn
     , testRecordReturnComplex
     , testRecordReturnExcessive
+    , testTupleReturnMany
+    , testRecordReturnMany
     , testRecordParams
     , testUpdateReturnRowCount
     , testMultiQuery
@@ -118,6 +120,22 @@ testRecordReturnExcessive conn = testCase "Return record from SELECT (extra valu
     let expected :: Maybe User
         expected = Just $ User 1 "billy"
     assertEqual "" expected actual
+
+testTupleReturnMany :: Connection -> TestTree
+testTupleReturnMany conn = testCase "Return a list of single-element tuples" $ do
+  actual <- [yesh|
+    -- name:getUsers :: [(String)]
+    select username from Users|] conn
+  let expected = ["billy", "billy"]
+  assertEqual "" expected actual
+
+testRecordReturnMany :: Connection -> TestTree
+testRecordReturnMany conn = testCase "Return a list of records from SELECT" $ do
+  actual <- [yesh|
+    -- name:getUsers :: [User]
+    select id, username from Users|] conn
+  let expected = [User 1 "billy", User 2 "billy"]
+  assertEqual "" expected actual
 
 testRecordParams :: Connection -> TestTree
 testRecordParams conn = testCase "Pass records as params" $ do

--- a/postgresql-simple/yeshql-postgresql-simple.cabal
+++ b/postgresql-simple/yeshql-postgresql-simple.cabal
@@ -44,7 +44,6 @@ test-suite tests
                  , tasty-hunit
                  , tasty-quickcheck
                  , yeshql-postgresql-simple
-    ghc-options: -ddump-splices
     hs-source-dirs: tests
     main-is: tests.hs
     other-modules: Database.YeshQL.PostgreSQL.Tests


### PR DESCRIPTION
Apparently I simply forgot to actually implement these and didn’t notice because the tests didn’t use them, sorry about that :/